### PR TITLE
fix: specify UTF-8 encoding when opening XML and Java files to prevent UnicodeDecodeError on Windows

### DIFF
--- a/ParserNecessities/MisarParserJava.py
+++ b/ParserNecessities/MisarParserJava.py
@@ -403,7 +403,7 @@ def java_main_parser(metamodel, module_name, module_project, multi_module_projec
         if '/src/test/' not in java_file:
             print('java_file = {}'.format(os.path.basename(java_file)))
             try:
-                with open(java_file) as file:
+                with open(java_file, encoding='utf-8') as file:
                     tree = javalang.parse.parse(file.read())
                     java_element = metamodel.JavaUserDefinedType()
                     imports = []

--- a/ParserNecessities/MisarParserJava.py
+++ b/ParserNecessities/MisarParserJava.py
@@ -403,7 +403,7 @@ def java_main_parser(metamodel, module_name, module_project, multi_module_projec
         if '/src/test/' not in java_file:
             print('java_file = {}'.format(os.path.basename(java_file)))
             try:
-                with open(java_file, encoding='utf-8') as file:
+                with open(java_file, encoding='utf-8-sig') as file:
                     tree = javalang.parse.parse(file.read())
                     java_element = metamodel.JavaUserDefinedType()
                     imports = []

--- a/ParserNecessities/MisarParserMain.py
+++ b/ParserNecessities/MisarParserMain.py
@@ -62,7 +62,7 @@ def yaml_to_dict(filename):
 
 def xml_to_dict(filename):
     xml_dict = {}
-    with open(filename, encoding='utf-8') as file:
+    with open(filename, 'rb') as file:
         xml_dict = xmltodict.parse(file.read())
     return xml_dict
 

--- a/ParserNecessities/MisarParserMain.py
+++ b/ParserNecessities/MisarParserMain.py
@@ -62,7 +62,7 @@ def yaml_to_dict(filename):
 
 def xml_to_dict(filename):
     xml_dict = {}
-    with open(filename) as file:
+    with open(filename, encoding='utf-8') as file:
         xml_dict = xmltodict.parse(file.read())
     return xml_dict
 


### PR DESCRIPTION
Fixes #21
Fixes #22

## Summary
`MisarParserMain.py` and `MisarParserJava.py` both open files without specifying an encoding, causing Python to fall back to the Windows default (`cp1252`). When files contain non-ASCII characters, this results in a `UnicodeDecodeError`. The XML reader crashes before any parsing begins; the Java reader silently skips affected files, producing an incomplete PSM.

## Changes
- `MisarParserMain.py` - `xml_to_dict`: added `encoding='utf-8'` to `open(filename)`
- `MisarParserJava.py` - `java_main_parser`: added `encoding='utf-8'` to `open(java_file)`

## Testing
Validated against the TrainTicket benchmark on Python 3.14.0, Windows 11.
- Before: parser crashed on TrainTicket root `pom.xml` before processing any services
- After: parser reads all XML files successfully and no longer silently skips Java files with non-ASCII characters

cc @aljvdi @MicroServiceArchitectureRecovery 